### PR TITLE
docs: adjust get started steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A simple golang scaffolding to help me to create new api projects or workers wit
 
 How to develop with this project.
 
-### VS Code and Remote-Control Plugin
+### VS Code and Remote Containers Plugin
 
-1. Install Remote-Control plugin on VS Code.
-2. copy file ./env/application.env.sample to ./env/application.env
-3. Reopen in Container mode, like [this](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+1. Install [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) plugin on VS Code.
+2. Copy file `./env/application.env.sample` to `./env/application.env`
+3. Reopen in Container mode: on Command Palette run `Remote-Containers: Open Folder in Container...` and select the local folder.
 4. Run the command `make hot`, for start with hot reload or on main.go file opened debug with pressing "f5".


### PR DESCRIPTION
**Problema:**
Dificuldade ao tentar executar os passos (get started) do Readme pra executar o projeto:
- Nome da extensão do Visual Studio Code é Remote Containers e não Remote Control, dificultando localizar a extensão.
- O terceiro passo de como executar não estava claro, pois apenas tinha um link redirecionado pra página da extensão, não exatamente pra parte que ensina a executar

**Solução/Ajustes:**
- Ajustado o nome da extensão e adicionado link pra ela
- O passo de "como executar" foi copiado da documentação da extensão