### PR TITLE
feat: updating golangci-lint to v3 and adding lint fix to makefile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,22 +5,21 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-      # reverting to 1.17.2 because of tls bug
-        go-version: '1.17.2'
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
 
-    - name: Generate auxiliary files
-      run: |
-        make generate
-
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: latest
-        only-new-issues: true
-        skip-go-installation: true
+      - name: Generate auxiliary files
+        run: |
+          make generate
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          only-new-issues: true

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ LD_FLAGS=-ldflags="-X $(MODULE_NAME)/internal/config.gitCommitHash=$(GIT_COMMIT_
 lint:
 	@golangci-lint run
 
+.PHONY: lint-fix
+lint-fix:
+	@golangci-lint run --fix
+
 .PHONY: api
 api:
 	@go run $(LD_FLAGS) cmd/api/main.go 


### PR DESCRIPTION
Fiz uma atualização do `golangci-lint` para a versão 3 (que já estamos usando em finance) e acrescentei o lint-fix no makefile